### PR TITLE
add example to JsonSchema, fix wrap for complicated wrap object

### DIFF
--- a/lib/helpers/json-schema.js
+++ b/lib/helpers/json-schema.js
@@ -172,6 +172,39 @@ JsonSchema.prototype.sample = function() {
 };
 
 /**
+ * Generates example data from the schema if possible. If not generate sample data.
+ *
+ * @returns {*}
+ */
+JsonSchema.prototype.example = function() {
+  if (this.schema.example)
+    return this.schema.example;
+
+  switch (this.schema.type) {
+    case 'array':
+      var item = new JsonSchema(this.schema.items);
+      return new Array(item.example());
+
+    case 'string':
+      if (this.schema.enum)
+        return this.schema.enum[Math.round(Math.random() * this.schema.enum.length)];
+      return this.sample();
+
+    case 'object':
+    case undefined:
+      var obj = {};
+      var schema = this.schema;
+      _.keys(this.schema.properties).forEach(function(propName) {
+        var propSchema = new JsonSchema(schema.properties[propName]);
+        obj[propName] = propSchema.example();
+      });
+      return obj;
+    default:
+      return this.sample();
+  }
+}
+
+/**
  * Returns the given value, or the default value if the given value is empty.
  */
 function getValueToValidate(schema, value) {

--- a/lib/mock/semantic-response.js
+++ b/lib/mock/semantic-response.js
@@ -3,7 +3,8 @@
 module.exports = SemanticResponse;
 
 var _    = require('lodash'),
-    util = require('../helpers/util');
+    util = require('../helpers/util'),
+    JsonSchema = require('../helpers/json-schema');
 
 /**
  * Describes the semantics of a Swagger response.
@@ -87,6 +88,9 @@ function SemanticResponse(response, path) {
 SemanticResponse.prototype.wrap = function(data) {
   if (this.isWrapped) {
     var wrapper = {};
+    if(this.schema) {
+      wrapper = new JsonSchema(this.schema).example()
+    }
     wrapper[this.wrapperProperty] = data;
     return wrapper;
   }


### PR DESCRIPTION
There is 2 fixes:
1) add posibility to use example information in JsonSchema
2) fix wrapping collection with complicating wrap object.
For example:

```
swagger: '2.0'
info:
  version: 0.1.0
  title: Test

paths:
  /items:
    get:
      responses:
        200:
          description: Success
          schema:
            properties:
              status:
                type: string
                example: success
              pagination:
                $ref: '#/definitions/PAGINATION'
              items:
                type: array
                items:
                  $ref: '#/definitions/ITEM'
definitions:
  ITEM:
    properties:
      id:
        type: integer
        example: 12
      name:
        type: string
        example: name
  PAGINATION:
    properties:
      per_page:
        type: integer
        example: 15
      current_page:
        type: integer
        example: 1
      total_pages:
        type: integer
        example: 1
```

Properties `pagination` and `status` not exist in mock without that fix. 
