### PR TITLE
Prevent filtering on properties that does not belong to the response schema

### DIFF
--- a/lib/mock/query-collection.js
+++ b/lib/mock/query-collection.js
@@ -131,7 +131,7 @@ function filter(resources, req, res) {
       // Build the filter object
       var filterCriteria = {data: {}};
       queryParams.forEach(function(param) {
-        if (req.query[param.name] !== undefined && res.swagger.schema.items.properties[param.name]) {
+        if (req.query[param.name] !== undefined && hasPropertyInSchema(res.swagger.schema, param.name)) {
           setDeepProperty(filterCriteria.data, param.name, req.query[param.name]);
         }
       });
@@ -146,6 +146,27 @@ function filter(resources, req, res) {
   }
 
   return resources;
+}
+
+function hasPropertyInSchema(schema, properties) {
+
+  if ('string' === typeof properties) {
+    properties = properties.split('.');
+  }
+
+  var prop = schema;
+  for (var i = 0 ; i < properties.length ; i++) {
+    var propName = properties[i];
+    if (prop.properties) {
+      prop = prop.properties[propName];
+    } else if (prop.items && prop.items.properties) {
+      prop = prop.items.properties[propName];
+    } else {
+      return null;
+    }
+  }
+
+  return prop;
 }
 
 /**

--- a/lib/mock/query-collection.js
+++ b/lib/mock/query-collection.js
@@ -26,7 +26,7 @@ var _    = require('lodash'),
 function queryCollection(req, res, next, dataStore) {
   dataStore.getCollection(req.path, function(err, resources) {
     if (!err) {
-      resources = filter(resources, req);
+      resources = filter(resources, req, res);
 
       if (resources.length === 0) {
         // There is no data, so use the current date/time as the "last-modified" header
@@ -73,7 +73,7 @@ function deleteCollection(req, res, next, dataStore) {
     }
     else {
       // Determine which resources to delete, based on query params
-      var resourcesToDelete = filter(resources, req);
+      var resourcesToDelete = filter(resources, req, res);
 
       if (resourcesToDelete.length === 0) {
         sendResponse(null, []);
@@ -121,7 +121,7 @@ function deleteCollection(req, res, next, dataStore) {
  * @param   {Request}       req
  * @returns {Resource[]}
  */
-function filter(resources, req) {
+function filter(resources, req, res) {
   util.debug('There are %d resources in %s', resources.length, req.path);
 
   if (resources.length > 0) {
@@ -131,7 +131,7 @@ function filter(resources, req) {
       // Build the filter object
       var filterCriteria = {data: {}};
       queryParams.forEach(function(param) {
-        if (req.query[param.name] !== undefined) {
+        if (req.query[param.name] !== undefined && res.swagger.schema.items.properties[param.name]) {
           setDeepProperty(filterCriteria.data, param.name, req.query[param.name]);
         }
       });

--- a/tests/specs/mock/query-collection.spec.js
+++ b/tests/specs/mock/query-collection.spec.js
@@ -782,6 +782,26 @@ describe('Query Collection Mock', function() {
           }
         );
 
+        it('should not filter by properties that are defined in the Swagger API but not in the response',
+          function(done) {
+
+            api.paths['/pets'][method].parameters.push({
+              name: 'page',
+              in: 'query',
+              description: 'Pagination index',
+              required: false,
+              type: 'integer',
+            });
+
+            helper.initTest(dataStore, api, function(supertest) {
+              var request = supertest[method]('/api/pets?page=2&Name=Lassie&Vet.Address.Street=123%20First%20St.');
+              noHeaders || request.expect('Content-Length', 1033);
+              request.expect(200, noBody ? '' : allPets);
+              request.end(helper.checkResults(done));
+            });
+          }
+        );
+
         it('should only filter by properties that are defined in the Swagger API',
           function(done) {
             helper.initTest(dataStore, api, function(supertest) {

--- a/tests/specs/request-validator.spec.js
+++ b/tests/specs/request-validator.spec.js
@@ -85,7 +85,7 @@ describe('RequestValidator middleware', function() {
     function(done) {
       api = files.parsed.petsPostOperation;
       initTest(function(err, middleware) {
-        expect(err.message).to.contain('The object is not a valid Swagger API definition');
+        expect(err.message).to.contain('[object Object] is not a valid Swagger API definition');
         done();
       });
     }
@@ -849,4 +849,3 @@ describe('RequestValidator middleware', function() {
 
   });
 });
-


### PR DESCRIPTION
This request fix an issue with filtering results with query parameters that are not part of the response schema.
Typically pagination or api keys parameters can be declared as query parameters but should not be use to filter results.
