### PR TITLE
Fix date validation inside an array / Remove date min and max

### DIFF
--- a/lib/helpers/json-schema.js
+++ b/lib/helpers/json-schema.js
@@ -625,41 +625,7 @@ function parseDate(schema, value, propPath) {
     }
   }
 
-  if (schema.minimum) {
-    var minDate = new Date(schema.minimum);
-    if (isNaN(minDate.getTime())) {
-      throw ono({status: 500}, 'The "minimum" value in the Swagger API is invalid (%j)', schema.minimum);
-    }
-
-    if (parsedValue < minDate) {
-      throw ono({status: 400}, '%s (%j) is less than minimum %j', propPath || 'Value', parsedValue, minDate);
-    }
-
-    if (schema.exclusiveMinimum === true) {
-      if (parsedValue.getTime() === minDate.getTime()) {
-        throw ono({status: 400}, '%s (%j) is equal to exclusive minimum %j', propPath || 'Value', parsedValue, minDate);
-      }
-    }
-  }
-
-  if (schema.maximum) {
-    var maxDate = new Date(schema.maximum);
-    if (isNaN(maxDate.getTime())) {
-      throw ono({status: 500}, 'The "maximum" value in the Swagger API is invalid (%j)', schema.maximum);
-    }
-
-    if (parsedValue > maxDate) {
-      throw ono({status: 400}, '%s (%j) is greater than maximum %j', propPath || 'Value', parsedValue, maxDate);
-    }
-
-    if (schema.exclusiveMaximum === true) {
-      if (parsedValue.getTime() === maxDate.getTime()) {
-        throw ono({status: 400}, '%s (%j) is equal to exclusive maximum %j', propPath || 'Value', parsedValue, maxDate);
-      }
-    }
-  }
-
-  return parsedValue;
+  return value;
 }
 
 function serializeDate(schema, value, propPath) {
@@ -678,22 +644,8 @@ function serializeDate(schema, value, propPath) {
 }
 
 function sampleDate(schema) {
-  var min, max;
-  if (schema.minimum !== undefined) {
-    min = parseInt(new Date(schema.minimum).valueOf()) + (schema.exclusiveMinimum ? 1 : 0);
-  }
-  else {
-    min = Date.UTC(1970, 0, 1);
-    min = Math.min(min, new Date(schema.maximum).valueOf()) || min;
-  }
-
-  if (schema.maximum !== undefined) {
-    max = parseInt(new Date(schema.maximum).valueOf()) - (schema.exclusiveMaximum ? 1 : 0);
-  }
-  else {
-    max = Math.max(Date.now(), min);
-  }
-
+  var min = Date.UTC(1970, 0, 1);
+  var max = Date.now();
   var date = new Date(_.random(min, max));
 
   if (schema.format === 'date') {

--- a/lib/helpers/json-schema.js
+++ b/lib/helpers/json-schema.js
@@ -604,25 +604,19 @@ function parseDate(schema, value, propPath) {
   // Handle missing, required, and default
   value = getValueToValidate(schema, value);
 
-  // If the value is already a Date, then we can skip some validation
-  if (_.isDate(value)) {
-    parsedValue = value;
+  // Validate against the schema
+  jsonValidate(schema, value, propPath);
+
+  // Validate the format
+  var formatPattern = dataTypePatterns[schema.format];
+  if (!formatPattern.test(value)) {
+    throw ono({status: 400}, '"%s" is not a properly-formatted %s', propPath || value, schema.format);
   }
-  else {
-    // Validate against the schema
-    jsonValidate(schema, value, propPath);
 
-    // Validate the format
-    var formatPattern = dataTypePatterns[schema.format];
-    if (!formatPattern.test(value)) {
-      throw ono({status: 400}, '"%s" is not a properly-formatted %s', propPath || value, schema.format);
-    }
-
-    // Parse the date
-    parsedValue = new Date(value);
-    if (!parsedValue || isNaN(parsedValue.getTime())) {
-      throw ono({status: 400}, '"%s" is an invalid %s', propPath || value, schema.format);
-    }
+  // Parse the date
+  parsedValue = new Date(value);
+  if (!parsedValue || isNaN(parsedValue.getTime())) {
+    throw ono({status: 400}, '"%s" is an invalid %s', propPath || value, schema.format);
   }
 
   return value;

--- a/lib/param-parser.js
+++ b/lib/param-parser.js
@@ -124,7 +124,6 @@ function parseParameter(param, value, schema) {
     if (param.required) {
       // The parameter is required, but was not provided, so throw a 400 error
       var errCode = 400;
-
       if (param.in === 'header' && param.name.toLowerCase() === 'content-length') {
         // Special case for the Content-Length header.  It has it's own HTTP error code.
         errCode = 411; // (Length Required)

--- a/tests/specs/json-schema/parse/parse-array.spec.js
+++ b/tests/specs/json-schema/parse/parse-array.spec.js
@@ -80,8 +80,8 @@ describe('JSON Schema - parse array params', function() {
 
       express.post('/api/test', helper.spy(function(req, res, next) {
         expect(req.header('Test')).to.have.lengthOf(2);
-        expect(req.header('Test')[0]).to.equalTime(new Date('1999-12-31'));
-        expect(req.header('Test')[1]).to.equalTime(new Date('2000-04-22'));
+        expect(req.header('Test')[0]).to.equal('1999-12-31');
+        expect(req.header('Test')[1]).to.equal('2000-04-22');
       }));
     }
   );
@@ -172,8 +172,33 @@ describe('JSON Schema - parse array params', function() {
 
       express.post('/api/test', helper.spy(function(req, res, next) {
         expect(req.header('Test')).to.have.lengthOf(2);
-        expect(req.header('Test')[0]).to.equalTime(new Date('2008-06-30T13:40:50Z'));
-        expect(req.header('Test')[1]).to.equalTime(new Date('1990-01-01T00:00:00-15:45'));
+        expect(req.header('Test')[0]).to.equal('2008-06-30T13:40:50Z');
+        expect(req.header('Test')[1]).to.equal('1990-01-01T00:00:00-15:45');
+      }));
+    }
+  );
+
+  it('should parse array items as objects with dates',
+    function(done) {
+      var schema = {
+        type: 'array',
+        items: {
+          type: 'object',
+          properties: {
+            date: {
+              type: 'string',
+              format: 'date'
+            }
+          }
+        }
+      };
+
+      var express = helper.parse(schema, '{"date":"2008-06-30"},{"date":"1990-01-01"}', done);
+
+      express.post('/api/test', helper.spy(function(req, res, next) {
+        expect(req.header('Test')).to.have.lengthOf(2);
+        expect(req.header('Test')[0].date).to.equal('2008-06-30');
+        expect(req.header('Test')[1].date).to.equal('1990-01-01');
       }));
     }
   );

--- a/tests/specs/json-schema/parse/parse-date-time.spec.js
+++ b/tests/specs/json-schema/parse/parse-date-time.spec.js
@@ -11,17 +11,13 @@ describe('JSON Schema - parse date-time params', function() {
     function(done) {
       var schema = {
         type: 'string',
-        format: 'date-time',
-        minimum: new Date(Date.UTC(2010, 0, 1)),
-        exclusiveMinimum: true,
-        maximum: '2010-12-31T23:59:59.999Z',
-        exclusiveMaximum: false
+        format: 'date-time'
       };
 
       var express = helper.parse(schema, '2010-12-31T23:59:59.999Z', done);
 
       express.post('/api/test', helper.spy(function(req, res, next) {
-        expect(req.header('Test')).to.equalTime(new Date('2010-12-31T23:59:59.999Z'));
+        expect(req.header('Test')).to.equal('2010-12-31T23:59:59.999Z');
       }));
     }
   );
@@ -52,23 +48,7 @@ describe('JSON Schema - parse date-time params', function() {
       var express = helper.parse(schema, undefined, done);
 
       express.post('/api/test', helper.spy(function(req, res, next) {
-        expect(req.header('Test')).to.equalTime(new Date('1990-09-13T12:00:00Z'));
-      }));
-    }
-  );
-
-  it('should parse the default date-time value if no value is specified',
-    function(done) {
-      var schema = {
-        type: 'string',
-        format: 'date-time',
-        default: new Date('1995-08-24T15:30:45-06:30')
-      };
-
-      var express = helper.parse(schema, undefined, done);
-
-      express.post('/api/test', helper.spy(function(req, res, next) {
-        expect(req.header('Test')).to.equalTime(new Date('1995-08-24T15:30:45-06:30'));
+        expect(req.header('Test')).to.equal('1990-09-13T12:00:00Z');
       }));
     }
   );
@@ -84,7 +64,7 @@ describe('JSON Schema - parse date-time params', function() {
       var express = helper.parse(schema, '', done);
 
       express.post('/api/test', helper.spy(function(req, res, next) {
-        expect(req.header('Test')).to.equalTime(new Date('2020-01-31T05:05:05-05:05'));
+        expect(req.header('Test')).to.equal('2020-01-31T05:05:05-05:05');
       }));
     }
   );
@@ -171,148 +151,6 @@ describe('JSON Schema - parse date-time params', function() {
         expect(err).to.be.an.instanceOf(Error);
         expect(err.status).to.equal(400);
         expect(err.message).to.contain('String is too long (29 chars), maximum 15');
-      }));
-    }
-  );
-
-  it('should throw an error if the value is above the maximum',
-    function(done) {
-      var schema = {
-        type: 'string',
-        format: 'date-time',
-        maximum: '2009-08-12'
-      };
-
-      var express = helper.parse(schema, '2009-08-12T00:00:00.001Z', done);
-
-      express.use('/api/test', helper.spy(function(err, req, res, next) {
-        expect(err).to.be.an.instanceOf(Error);
-        expect(err.status).to.equal(400);
-        expect(err.message).to.contain('is greater than maximum');
-      }));
-    }
-  );
-
-  it('should NOT throw an error if the value is equal to the maximum',
-    function(done) {
-      var schema = {
-        type: 'string',
-        format: 'date-time',
-        maximum: '2009-08-12'
-      };
-
-      var express = helper.parse(schema, '2009-08-12T00:00:00.000Z', done);
-
-      express.post('/api/test', helper.spy(function(req, res, next) {
-        expect(req.header('Test')).to.equalTime(new Date('2009-08-12T00:00:00.000Z'));
-      }));
-    }
-  );
-
-  it('should throw an error if the value is equal the exclusive maximum',
-    function(done) {
-      var schema = {
-        type: 'string',
-        format: 'date-time',
-        maximum: '2009-08-12T20:00:00-08:30',
-        exclusiveMaximum: true
-      };
-
-      var express = helper.parse(schema, '2009-08-12T20:00:00-08:30', done);
-
-      express.use('/api/test', helper.spy(function(err, req, res, next) {
-        expect(err).to.be.an.instanceOf(Error);
-        expect(err.status).to.equal(400);
-        expect(err.message).to.contain('is equal to exclusive maximum');
-      }));
-    }
-  );
-
-  it('should throw an error if the maximum is not valid',
-    function(done) {
-      var schema = {
-        type: 'string',
-        format: 'date-time',
-        maximum: '2009-12-27T19:20:76Z'
-      };
-
-      var express = helper.parse(schema, '2009-12-27T19:20:06Z', done);
-
-      express.use('/api/test', helper.spy(function(err, req, res, next) {
-        expect(err).to.be.an.instanceOf(Error);
-        expect(err.status).to.equal(500);
-        expect(err.message).to.contain('The "maximum" value in the Swagger API is invalid ("2009-12-27T19:20:76Z")');
-      }));
-    }
-  );
-
-  it('should throw an error if the value is below the minimum',
-    function(done) {
-      var schema = {
-        type: 'string',
-        format: 'date-time',
-        minimum: '2009-08-12'
-      };
-
-      var express = helper.parse(schema, '2009-08-11T23:59:59.999Z', done);
-
-      express.use('/api/test', helper.spy(function(err, req, res, next) {
-        expect(err).to.be.an.instanceOf(Error);
-        expect(err.status).to.equal(400);
-        expect(err.message).to.contain('is less than minimum');
-      }));
-    }
-  );
-
-  it('should NOT throw an error if the value is equal to the minimum',
-    function(done) {
-      var schema = {
-        type: 'string',
-        format: 'date-time',
-        minimum: '2009-08-12'
-      };
-
-      var express = helper.parse(schema, '2009-08-12T00:00:00.000Z', done);
-
-      express.post('/api/test', helper.spy(function(req, res, next) {
-        expect(req.header('Test')).to.equalTime(new Date('2009-08-12'));
-      }));
-    }
-  );
-
-  it('should throw an error if the value is equal the exclusive minimum',
-    function(done) {
-      var schema = {
-        type: 'string',
-        format: 'date-time',
-        minimum: '2009-08-12',
-        exclusiveMinimum: true
-      };
-
-      var express = helper.parse(schema, '2009-08-12T00:00:00.000Z', done);
-
-      express.use('/api/test', helper.spy(function(err, req, res, next) {
-        expect(err).to.be.an.instanceOf(Error);
-        expect(err.status).to.equal(400);
-        expect(err.message).to.contain('is equal to exclusive minimum');
-      }));
-    }
-  );
-
-  it('should throw an error if the minimum is not valid',
-    function(done) {
-      var schema = {
-        type: 'string',
-        format: 'date-time',
-        minimum: '2009-11-27T19:05:80Z'
-      };
-
-      var express = helper.parse(schema, '2009-11-27T19:05:08Z', done);
-
-      express.use('/api/test', helper.spy(function(err, req, res, next) {
-        expect(err).to.be.an.instanceOf(Error);
-        expect(err.status).to.equal(500);
-        expect(err.message).to.contain('The "minimum" value in the Swagger API is invalid ("2009-11-27T19:05:80Z")');
       }));
     }
   );

--- a/tests/specs/json-schema/parse/parse-date.spec.js
+++ b/tests/specs/json-schema/parse/parse-date.spec.js
@@ -11,17 +11,13 @@ describe('JSON Schema - parse date params', function() {
     function(done) {
       var schema = {
         type: 'string',
-        format: 'date',
-        minimum: new Date(Date.UTC(2010, 0, 1)),
-        exclusiveMinimum: true,
-        maximum: '2010-12-31',
-        exclusiveMaximum: false
+        format: 'date'
       };
 
       var express = helper.parse(schema, '2010-12-31', done);
 
       express.post('/api/test', helper.spy(function(req, res, next) {
-        expect(req.header('Test')).to.equalTime(new Date('2010-12-31'));
+        expect(req.header('Test')).to.equal('2010-12-31');
       }));
     }
   );
@@ -52,23 +48,7 @@ describe('JSON Schema - parse date params', function() {
       var express = helper.parse(schema, undefined, done);
 
       express.post('/api/test', helper.spy(function(req, res, next) {
-        expect(req.header('Test')).to.equalTime(new Date('1990-09-13'));
-      }));
-    }
-  );
-
-  it('should parse the default Date value if no value is specified',
-    function(done) {
-      var schema = {
-        type: 'string',
-        format: 'date',
-        default: new Date('1995-08-24')
-      };
-
-      var express = helper.parse(schema, undefined, done);
-
-      express.post('/api/test', helper.spy(function(req, res, next) {
-        expect(req.header('Test')).to.equalTime(new Date('1995-08-24'));
+        expect(req.header('Test')).to.equal('1990-09-13');
       }));
     }
   );
@@ -84,7 +64,7 @@ describe('JSON Schema - parse date params', function() {
       var express = helper.parse(schema, '', done);
 
       express.post('/api/test', helper.spy(function(req, res, next) {
-        expect(req.header('Test')).to.equalTime(new Date('2020-01-31'));
+        expect(req.header('Test')).to.equal('2020-01-31');
       }));
     }
   );
@@ -171,148 +151,6 @@ describe('JSON Schema - parse date params', function() {
         expect(err).to.be.an.instanceOf(Error);
         expect(err.status).to.equal(400);
         expect(err.message).to.contain('String is too long (10 chars), maximum 5');
-      }));
-    }
-  );
-
-  it('should throw an error if the value is above the maximum',
-    function(done) {
-      var schema = {
-        type: 'string',
-        format: 'date',
-        maximum: '2009-08-12'
-      };
-
-      var express = helper.parse(schema, '2009-08-13', done);
-
-      express.use('/api/test', helper.spy(function(err, req, res, next) {
-        expect(err).to.be.an.instanceOf(Error);
-        expect(err.status).to.equal(400);
-        expect(err.message).to.contain('is greater than maximum');
-      }));
-    }
-  );
-
-  it('should NOT throw an error if the value is equal to the maximum',
-    function(done) {
-      var schema = {
-        type: 'string',
-        format: 'date',
-        maximum: '2009-08-12'
-      };
-
-      var express = helper.parse(schema, '2009-08-12', done);
-
-      express.post('/api/test', helper.spy(function(req, res, next) {
-        expect(req.header('Test')).to.equalTime(new Date('2009-08-12'));
-      }));
-    }
-  );
-
-  it('should throw an error if the value is equal the exclusive maximum',
-    function(done) {
-      var schema = {
-        type: 'string',
-        format: 'date',
-        maximum: '2009-08-12',
-        exclusiveMaximum: true
-      };
-
-      var express = helper.parse(schema, '2009-08-12', done);
-
-      express.use('/api/test', helper.spy(function(err, req, res, next) {
-        expect(err).to.be.an.instanceOf(Error);
-        expect(err.status).to.equal(400);
-        expect(err.message).to.contain('is equal to exclusive maximum');
-      }));
-    }
-  );
-
-  it('should throw an error if the maximum is not valid',
-    function(done) {
-      var schema = {
-        type: 'string',
-        format: 'date',
-        maximum: '2009-15-27'
-      };
-
-      var express = helper.parse(schema, '2009-08-12', done);
-
-      express.use('/api/test', helper.spy(function(err, req, res, next) {
-        expect(err).to.be.an.instanceOf(Error);
-        expect(err.status).to.equal(500);
-        expect(err.message).to.contain('The "maximum" value in the Swagger API is invalid ("2009-15-27")');
-      }));
-    }
-  );
-
-  it('should throw an error if the value is below the minimum',
-    function(done) {
-      var schema = {
-        type: 'string',
-        format: 'date',
-        minimum: '2009-08-12'
-      };
-
-      var express = helper.parse(schema, '2009-08-11', done);
-
-      express.use('/api/test', helper.spy(function(err, req, res, next) {
-        expect(err).to.be.an.instanceOf(Error);
-        expect(err.status).to.equal(400);
-        expect(err.message).to.contain('is less than minimum');
-      }));
-    }
-  );
-
-  it('should NOT throw an error if the value is equal to the minimum',
-    function(done) {
-      var schema = {
-        type: 'string',
-        format: 'date',
-        minimum: '2009-08-12'
-      };
-
-      var express = helper.parse(schema, '2009-08-12', done);
-
-      express.post('/api/test', helper.spy(function(req, res, next) {
-        expect(req.header('Test')).to.equalTime(new Date('2009-08-12'));
-      }));
-    }
-  );
-
-  it('should throw an error if the value is equal the exclusive minimum',
-    function(done) {
-      var schema = {
-        type: 'string',
-        format: 'date',
-        minimum: '2009-08-12',
-        exclusiveMinimum: true
-      };
-
-      var express = helper.parse(schema, '2009-08-12', done);
-
-      express.use('/api/test', helper.spy(function(err, req, res, next) {
-        expect(err).to.be.an.instanceOf(Error);
-        expect(err.status).to.equal(400);
-        expect(err.message).to.contain('is equal to exclusive minimum');
-      }));
-    }
-  );
-
-  it('should throw an error if the minimum is not valid',
-    function(done) {
-      var schema = {
-        type: 'string',
-        format: 'date',
-        minimum: '2009-15-27'
-      };
-
-      var express = helper.parse(schema, '2009-08-12', done);
-
-      express.use('/api/test', helper.spy(function(err, req, res, next) {
-        expect(err).to.be.an.instanceOf(Error);
-        expect(err.status).to.equal(500);
-        expect(err.message).to.contain('The "minimum" value in the Swagger API is invalid ("2009-15-27")');
       }));
     }
   );

--- a/tests/specs/json-schema/sample.spec.js
+++ b/tests/specs/json-schema/sample.spec.js
@@ -265,84 +265,6 @@ describe('JSON Schema sample data', function() {
         }
       }
     );
-
-    it('should generate a valid date above minimum',
-      function() {
-        var min = new Date();
-        min.setUTCMilliseconds(0);
-        var schema = new JsonSchema({type: 'string', format: 'date-time', minimum: min});
-        for (var i = 0; i < iterations; i++) {
-          var date = schema.sample();
-          expect(date).to.be.an.instanceOf(Date);
-          expect(date.valueOf()).to.be.at.least(min.valueOf());
-        }
-      }
-    );
-
-    it('should generate a valid date above exclusive minimum',
-      function() {
-        var min = new Date();
-        min.setUTCMilliseconds(0);
-        var schema = new JsonSchema({type: 'string', format: 'date-time', minimum: min, exclusiveMinimum: true});
-        for (var i = 0; i < iterations; i++) {
-          expect(schema.sample())
-            .to.be.an.instanceOf(Date)
-            .and.afterTime(min);
-        }
-      }
-    );
-
-    it('should generate a valid date below maximum',
-      function() {
-        var max = new Date(Date.UTC(1970, 0, 1, 0, 0, 0, 10));
-        var schema = new JsonSchema({type: 'string', format: 'date-time', maximum: max});
-        for (var i = 0; i < iterations; i++) {
-          var date = schema.sample();
-          expect(date).to.be.an.instanceOf(Date);
-          expect(date.valueOf()).to.be.at.most(max.valueOf());
-        }
-      }
-    );
-
-    it('should generate a valid date below exclusive maximum',
-      function() {
-        var max = new Date(Date.UTC(1970, 0, 1, 0, 0, 0, 10));
-        var schema = new JsonSchema({type: 'string', format: 'date-time', maximum: max, exclusiveMaximum: true});
-        for (var i = 0; i < iterations; i++) {
-          expect(schema.sample())
-            .to.be.an.instanceOf(Date)
-            .and.beforeTime(max);
-        }
-      }
-    );
-
-    it('should generate a valid date within min/max',
-      function() {
-        var min = new Date(2008, 5, 27, 15, 32, 17, 100);
-        var max = new Date(2008, 5, 27, 15, 32, 17, 200);
-        var schema = new JsonSchema({type: 'string', format: 'date-time', minimum: min, maximum: max});
-        for (var i = 0; i < iterations; i++) {
-          var date = schema.sample();
-          expect(date).to.be.an.instanceOf(Date);
-          expect(date.valueOf()).to.be.at.least(min.valueOf());
-          expect(date.valueOf()).to.be.at.most(max.valueOf());
-        }
-      }
-    );
-
-    it('should generate a valid date within exclusive min/max',
-      function() {
-        var min = new Date(2008, 5, 27, 15, 32, 17, 100);
-        var max = new Date(2008, 5, 27, 15, 32, 17, 200);
-        var schema = new JsonSchema({type: 'string', format: 'date-time', minimum: min, maximum: max, exclusiveMinimum: true, exclusiveMaximum: true});
-        for (var i = 0; i < iterations; i++) {
-          expect(schema.sample())
-            .to.be.an.instanceOf(Date)
-            .and.afterTime(min)
-            .and.beforeTime(max);
-        }
-      }
-    );
   });
 
   describe('sampleString', function() {
@@ -406,32 +328,6 @@ describe('JSON Schema sample data', function() {
           expect(array).to.be.an('array');
           array.forEach(function(item) {
             expect(item).to.be.a('number').at.least(1).and.at.most(10);
-          });
-        }
-      }
-    );
-
-    it('should generate an array of minItems',
-      function() {
-        var min = new Date(1995, 6, 18, 12, 30, 45, 0);
-        var max = new Date(1995, 6, 18, 12, 30, 45, 10);
-        var schema = new JsonSchema({
-          type: 'array',
-          minItems: 25,
-          items: {
-            type: 'string',
-            format: 'date-time',
-            minimum: min,
-            exclusiveMinimum: true,
-            maximum: max,
-            exclusiveMaximum: true
-          }
-        });
-        for (var i = 0; i < iterations; i++) {
-          var array = schema.sample();
-          expect(array).to.be.an('array').with.length.at.least(25);
-          array.forEach(function(item) {
-            expect(item).to.be.an.instanceOf(Date).afterTime(min).beforeTime(max);
           });
         }
       }

--- a/tests/specs/param-parser.spec.js
+++ b/tests/specs/param-parser.spec.js
@@ -318,7 +318,7 @@ describe('ParamParser middleware', function() {
     it('should throw an HTTP 411 error if the Content-Length header is required and is missing',
       function(done) {
         var api = _.cloneDeep(files.parsed.petStore);
-        api.paths['/pets'].post.parameters.push({
+        api.paths['/pets'].get.parameters.push({
           in: 'header',
           name: 'Content-Length',
           required: true,
@@ -329,7 +329,7 @@ describe('ParamParser middleware', function() {
           var express = helper.express(middleware.metadata(), middleware.parseRequest());
 
           helper.supertest(express)
-            .post('/api/pets')
+            .get('/api/pets')
             .end(helper.checkSpyResults(done));
 
           express.use('/api/pets', helper.spy(function(err, req, res, next) {

--- a/tests/specs/path-parser.spec.js
+++ b/tests/specs/path-parser.spec.js
@@ -190,8 +190,8 @@ describe('PathParser middleware', function() {
             intParam: -951,
             floatParam: 1576.179145671859,
             byteParam: 255,
-            dateParam: new Date('2010-11-04'),
-            timeParam: new Date('1900-08-14T02:04:55.987-03:00'),
+            dateParam: '2010-11-04',
+            timeParam: '1900-08-14T02:04:55.987-03:00',
             boolParam: true
           });
           expect(req.pathParams).to.deep.equal(req.params);

--- a/tests/specs/request-validator.spec.js
+++ b/tests/specs/request-validator.spec.js
@@ -85,7 +85,7 @@ describe('RequestValidator middleware', function() {
     function(done) {
       api = files.parsed.petsPostOperation;
       initTest(function(err, middleware) {
-        expect(err.message).to.contain('The object is not a valid Swagger API definition');
+        expect(err.message).to.contain('is not a valid Swagger API definition');
         done();
       });
     }


### PR DESCRIPTION
- Fix date validation inside an array
- Remove unsupported date minimum and maximum validation

JSONSchema validation was not working for dates nested inside the array.

Example:

```
var schema = new JsonSchema({
          type: 'object',
          properties: {
            arr: {
              type: 'array',
              items: {
                type: 'object',
                properties: {
                  date: {
                    type: 'string',
                    format: 'date'
                  }
                }
              }
            }
          }
        });

      schema.parse('{"arr":[{"date":"2016-01-01"}]}');
```

Problem was that string format date/date-time was casted to Date object and nested validation was failing. IMHO there is no need to cast the date at this point. 

During implementation I have removed unsupported minimum and maximum options from date and date-time. Swagger specification and JSON-schema specification specify minimum and maximum only on type number and it must be a number:

http://json-schema.org/latest/json-schema-validation.html#anchor17
https://github.com/OAI/OpenAPI-Specification/blob/master/versions/2.0.md
