### PR TITLE
Do not take example data

### DIFF
--- a/lib/helpers/json-schema.js
+++ b/lib/helpers/json-schema.js
@@ -184,9 +184,6 @@ function getValueToValidate(schema, value) {
     if (schema.default !== undefined) {
       value = schema.default;
     }
-    else if (schema.example !== undefined) {
-      value = schema.example;
-    }
   }
 
   // Special case for Buffers

--- a/tests/specs/mock/query-resource.spec.js
+++ b/tests/specs/mock/query-resource.spec.js
@@ -412,25 +412,6 @@ describe('Query Resource Mock', function() {
           }
         );
 
-        it('should return the example value instead of undefined',
-          function(done) {
-            api.paths['/pets/{PetName}'][method].responses[200].schema.example = {example: 'The example value'};
-            api.paths['/pets/{PetName}'][method].responses[200].schema.type = 'object';
-
-            var dataStore = new swagger.MemoryDataStore();
-            var resource = new swagger.Resource('/api/pets/Fido');
-            dataStore.save(resource, function() {
-              helper.initTest(dataStore, api, function(supertest) {
-                var request = supertest[method]('/api/pets/Fido');
-                noHeaders || request.expect('Content-Type', 'application/json; charset=utf-8');
-                noHeaders || request.expect('Content-Length', 31);
-                request.expect(200, noBody ? '' : {example: 'The example value'});
-                request.end(helper.checkResults(done));
-              });
-            });
-          }
-        );
-
         it('should return a null value',
           function(done) {
             api.paths['/pets/{PetName}'][method].responses[200].schema.type = 'object';


### PR DESCRIPTION
Example data should not be used to backfill the object. It is there
for documentation - unlike default property.

Fixes #66