### PR TITLE
bump lodash version

### DIFF
--- a/lib/data-store/resource.js
+++ b/lib/data-store/resource.js
@@ -254,7 +254,7 @@ function normalizeName(name) {
   }
 
   // Don't allow slashes in the middle
-  if (_.contains(name.substring(1, name.length - 1), '/')) {
+  if (_.includes(name.substring(1, name.length - 1), '/')) {
     throw ono('Resource names cannot contain slashes');
   }
 

--- a/lib/helpers/util.js
+++ b/lib/helpers/util.js
@@ -121,8 +121,8 @@ exports.rfc1123 = function(date) {
   var dayName = ['Sun', 'Mon', 'Tue', 'Wed', 'Thu', 'Fri', 'Sat'][date.getUTCDay()];
   var monthName = ['Jan', 'Feb', 'Mar', 'Apr', 'May', 'Jun', 'Jul', 'Aug', 'Sep', 'Oct', 'Nov', 'Dec'][date.getUTCMonth()];
   return [
-    dayName, ', ', _.padLeft(date.getUTCDate(), 2, '0'), ' ', monthName, ' ', date.getUTCFullYear(), ' ',
-    _.padLeft(date.getUTCHours(), 2, '0'), ':', _.padLeft(date.getUTCMinutes(), 2, '0'), ':', _.padLeft(date.getUTCSeconds(), 2, '0'), ' GMT'
+    dayName, ', ', _.padStart(date.getUTCDate(), 2, '0'), ' ', monthName, ' ', date.getUTCFullYear(), ' ',
+    _.padStart(date.getUTCHours(), 2, '0'), ':', _.padStart(date.getUTCMinutes(), 2, '0'), ':', _.padStart(date.getUTCSeconds(), 2, '0'), ' GMT'
   ].join('');
   // jscs:enable maximumLineLength
 };
@@ -209,7 +209,7 @@ exports.getParameters = function(path, operation) {
 
   // Combine the path and operation parameters,
   // with the operation params taking precedence over the path params
-  return _.unique(operationParams.concat(pathParams), function(param) {
+  return _.uniq(operationParams.concat(pathParams), function(param) {
     return param.name + param.in;
   });
 };
@@ -238,7 +238,7 @@ exports.getRequestSchema = function(path, operation) {
     var schema = {type: 'object', required: [], properties: {}};
 
     // If there are "formData" parameters, then concatenate them into a single JSON schema
-    _.where(params, {in: 'formData'}).forEach(function(param) {
+    _.filter(params, {in: 'formData'}).forEach(function(param) {
       schema.properties[param.name] = param;
       if (param.required) {
         schema.required.push(param.name);

--- a/lib/mock/edit-collection.js
+++ b/lib/mock/edit-collection.js
@@ -283,7 +283,7 @@ function getResourceNameByRequired(data, schema) {
  */
 function getResourceNameByFile(data, schema) {
   // Find all file parameters
-  var files = _.where(schema.properties, {type: 'file'});
+  var files = _.filter(schema.properties, {type: 'file'});
 
   // If there is exactly ONE file parameter, then we'll use its file name
   if (files.length === 1) {
@@ -338,7 +338,7 @@ function sendResponse(req, res, next, dataStore) {
       }
 
       // Extract the "data" of each Resource
-      resources = _.pluck(resources, 'data');
+      resources = _.map(resources, 'data');
     }
 
     // Set the response body (unless it's already been set by other middleware)
@@ -353,7 +353,7 @@ function sendResponse(req, res, next, dataStore) {
     else {
       // Response body is the entire collection (new, edited, and old)
       dataStore.getCollection(req.path, function(err, collection) {
-        res.body = _.pluck(collection, 'data');
+        res.body = _.map(collection, 'data');
         next(err);
       });
     }

--- a/lib/mock/edit-resource.js
+++ b/lib/mock/edit-resource.js
@@ -118,7 +118,7 @@ function sendResponse(req, res, next, dataStore) {
     else if (res.swagger.isCollection) {
       // Response body is the entire collection
       dataStore.getCollection(resource.collection, function(err, collection) {
-        res.body = _.pluck(collection, 'data');
+        res.body = _.map(collection, 'data');
         next(err);
       });
     }

--- a/lib/mock/query-collection.js
+++ b/lib/mock/query-collection.js
@@ -42,7 +42,7 @@ function queryCollection(req, res, next, dataStore) {
         res.swagger.lastModified = _.max(resources, 'modifiedOn').modifiedOn;
 
         // Extract the "data" of each Resource
-        resources = _.pluck(resources, 'data');
+        resources = _.map(resources, 'data');
       }
 
       // Set the response body (unless it's already been set by other middleware)
@@ -92,7 +92,7 @@ function deleteCollection(req, res, next, dataStore) {
   // Responds with the deleted resources
   function sendResponse(err, resources) {
     // Extract the "data" of each Resource
-    resources = _.pluck(resources, 'data');
+    resources = _.map(resources, 'data');
 
     // Use the current date/time as the "last-modified" header
     res.swagger.lastModified = new Date();
@@ -126,7 +126,7 @@ function filter(resources, req) {
 
   if (resources.length > 0) {
     // If there are query params, then filter the collection by them
-    var queryParams = _.where(req.swagger.params, {in: 'query'});
+    var queryParams = _.filter(req.swagger.params, {in: 'query'});
     if (queryParams.length > 0) {
       // Build the filter object
       var filterCriteria = {data: {}};
@@ -139,7 +139,7 @@ function filter(resources, req) {
       if (!_.isEmpty(filterCriteria.data)) {
         // Filter the collection
         util.debug('Filtering resources by %j', filterCriteria.data);
-        resources = _.where(resources, filterCriteria);
+        resources = _.filter(resources, filterCriteria);
         util.debug('%d resources matched the filter criteria', resources.length);
       }
     }

--- a/lib/path-parser.js
+++ b/lib/path-parser.js
@@ -78,7 +78,7 @@ function pathParser(context, router) {
       });
     }
 
-    return _.unique(params);
+    return _.uniq(params);
   }
 
   /**

--- a/package-lock.json
+++ b/package-lock.json
@@ -258,6 +258,12 @@
         "try-resolve": "1.0.1"
       },
       "dependencies": {
+        "lodash": {
+          "version": "3.10.1",
+          "resolved": "https://registry.npmjs.org/lodash/-/lodash-3.10.1.tgz",
+          "integrity": "sha1-W/Rejkm6QYnhfUgnid/RW9FAt7Y=",
+          "dev": true
+        },
         "source-map": {
           "version": "0.5.7",
           "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.7.tgz",
@@ -325,6 +331,14 @@
       "dev": true,
       "requires": {
         "lodash": "3.10.1"
+      },
+      "dependencies": {
+        "lodash": {
+          "version": "3.10.1",
+          "resolved": "https://registry.npmjs.org/lodash/-/lodash-3.10.1.tgz",
+          "integrity": "sha1-W/Rejkm6QYnhfUgnid/RW9FAt7Y=",
+          "dev": true
+        }
       }
     },
     "babel-plugin-react-constant-elements": {
@@ -2734,6 +2748,12 @@
             "inherit": "2.2.6"
           }
         },
+        "lodash": {
+          "version": "3.10.1",
+          "resolved": "https://registry.npmjs.org/lodash/-/lodash-3.10.1.tgz",
+          "integrity": "sha1-W/Rejkm6QYnhfUgnid/RW9FAt7Y=",
+          "dev": true
+        },
         "minimatch": {
           "version": "3.0.4",
           "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.4.tgz",
@@ -2768,6 +2788,14 @@
       "dev": true,
       "requires": {
         "lodash": "3.10.1"
+      },
+      "dependencies": {
+        "lodash": {
+          "version": "3.10.1",
+          "resolved": "https://registry.npmjs.org/lodash/-/lodash-3.10.1.tgz",
+          "integrity": "sha1-W/Rejkm6QYnhfUgnid/RW9FAt7Y=",
+          "dev": true
+        }
       }
     },
     "jsesc": {
@@ -2970,9 +2998,9 @@
       }
     },
     "lodash": {
-      "version": "3.10.1",
-      "resolved": "https://registry.npmjs.org/lodash/-/lodash-3.10.1.tgz",
-      "integrity": "sha1-W/Rejkm6QYnhfUgnid/RW9FAt7Y="
+      "version": "4.17.10",
+      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.10.tgz",
+      "integrity": "sha512-UejweD1pDoXu+AD825lWwp4ZGtSwgnpZxb3JDViD7StjQz+Nb/6l093lx4OQ0foGWNRoc19mWy7BzL+UAK2iVg=="
     },
     "lodash._baseassign": {
       "version": "3.2.0",
@@ -8268,6 +8296,14 @@
       "dev": true,
       "requires": {
         "lodash": "3.10.1"
+      },
+      "dependencies": {
+        "lodash": {
+          "version": "3.10.1",
+          "resolved": "https://registry.npmjs.org/lodash/-/lodash-3.10.1.tgz",
+          "integrity": "sha1-W/Rejkm6QYnhfUgnid/RW9FAt7Y=",
+          "dev": true
+        }
       }
     },
     "xtend": {

--- a/package.json
+++ b/package.json
@@ -54,7 +54,7 @@
     "body-parser": "^1.13.3",
     "cookie-parser": "^1.3.5",
     "debug": "^2.2.0",
-    "lodash": "^3.10.1",
+    "lodash": "^4.17.10",
     "mkdirp": "^0.5.1",
     "multer": "^0.1.8",
     "ono": "^1.0.22",

--- a/tests/specs/data-store/data-store.spec.js
+++ b/tests/specs/data-store/data-store.spec.js
@@ -327,7 +327,7 @@ describe('DataStore', function() {
         it('should throw an error if not called with a Resource object',
           function() {
             function throws() {
-              dataStore.get(_.cloneDeep(new Resource()));
+              dataStore.get(JSON.parse(JSON.stringify(new Resource())));
             }
 
             var dataStore = new DataStoreClass();
@@ -577,7 +577,7 @@ describe('DataStore', function() {
         it('should throw an error if not called with a Resource object',
           function() {
             function throws() {
-              dataStore.save(_.cloneDeep(new Resource()));
+              dataStore.save(JSON.parse(JSON.stringify(new Resource())));
             }
 
             var dataStore = new DataStoreClass();
@@ -769,7 +769,7 @@ describe('DataStore', function() {
         it('should throw an error if not called with an array of Resources',
           function() {
             function throws() {
-              dataStore.save(new Resource(), [new Resource(), _.cloneDeep(new Resource())]);
+              dataStore.save(new Resource(), [new Resource(), JSON.parse(JSON.stringify(new Resource()))]);
             }
 
             var dataStore = new DataStoreClass();
@@ -966,7 +966,7 @@ describe('DataStore', function() {
         it('should throw an error if not called with a Resource object',
           function() {
             function throws() {
-              dataStore.delete(_.cloneDeep(new Resource()));
+              dataStore.delete(JSON.parse(JSON.stringify(new Resource())));
             }
 
             var dataStore = new DataStoreClass();
@@ -1131,7 +1131,7 @@ describe('DataStore', function() {
         it('should throw an error if not called with an array of Resources',
           function() {
             function throws() {
-              dataStore.delete(new Resource(), [new Resource(), _.cloneDeep(new Resource())]);
+              dataStore.delete(new Resource(), [new Resource(), JSON.parse(JSON.stringify(new Resource()))]);
             }
 
             var dataStore = new DataStoreClass();


### PR DESCRIPTION
currently used lodash version has an identified vulnerability:
https://nodesecurity.io/advisories/577
this updates to latest version (that is patched for that vuln), and
updates usage on this lib,
luckily all breaking changes are just functions that got renamed.

they only tricky change was on test code, `_.cloneDeep` became smarter
and now produces that clone with same type (so `instanceof Resource` is
true), so I moved to use a dumber way of cloning for that test (JSON
parse+stringify).

Note this is reported on the project readme badge by david-dm
see:
![image](https://user-images.githubusercontent.com/384553/40252517-eafad8ae-5ab2-11e8-84c0-3ae3eb0a3141.png)
