### PR TITLE
Middleware documentation links do not work, fixing paths

### DIFF
--- a/docs/middleware/README.md
+++ b/docs/middleware/README.md
@@ -1,8 +1,8 @@
 Middleware
 ============================
-* [Mock middleware](middleware/mock.md)
-* [Metadata middleware](middleware/metadata.md)
-* [Parse Request middleware](middleware/parseRequest.md)
-* [Validate Request middleware](middleware/validateRequest.md)
-* [CORS middleware](middleware/CORS.md)
-* [Files middleware](middleware/files.md)
+* [Mock middleware](mock.md)
+* [Metadata middleware](metadata.md)
+* [Parse Request middleware](parseRequest.md)
+* [Validate Request middleware](validateRequest.md)
+* [CORS middleware](CORS.md)
+* [Files middleware](files.md)


### PR DESCRIPTION
This quick fix should get the links in the middleware documentation working properly, as can be seen at https://apidevtools.org/swagger-express-middleware/docs/middleware/ they are not currently working. 