### PR TITLE
Use servers instead of basePath with OpenAPI 3

### DIFF
--- a/lib/helpers/json-schema.js
+++ b/lib/helpers/json-schema.js
@@ -498,7 +498,12 @@ function parseObject (schema, value, propPath) {
   // Parse the value
   let parsedValue = value;
   if (_.isString(value) && value.length) {
-    parsedValue = JSON.parse(value);
+    try {
+      parsedValue = JSON.parse(value);
+    }
+    catch (e) {
+      throw ono({ status: 400 }, '"%s" is not a valid object: %s', value, e.message);
+    }
   }
 
   // Validate against the schema

--- a/lib/param-parser.js
+++ b/lib/param-parser.js
@@ -32,12 +32,12 @@ function parseSimpleParams (req, res, next) {
       switch (param.in) {
         case "query":
           util.debug('    Parsing the "%s" query parameter', param.name);
-          req.query[param.name] = parseParameter(param, req.query[param.name], param);
+          req.query[param.name] = parseParameter(param, req.query[param.name], param.schema || param);
           break;
         case "header":
           // NOTE: req.headers properties are always lower-cased
           util.debug('    Parsing the "%s" header parameter', param.name);
-          req.headers[param.name.toLowerCase()] = parseParameter(param, req.header(param.name), param);
+          req.headers[param.name.toLowerCase()] = parseParameter(param, req.header(param.name), param.schema || param);
           break;
       }
     });

--- a/lib/request-metadata.js
+++ b/lib/request-metadata.js
@@ -2,6 +2,7 @@
 
 module.exports = requestMetadata;
 
+const url = require("url");
 const util = require("./helpers/util");
 const _ = require("lodash");
 
@@ -30,10 +31,26 @@ function requestMetadata (context, router) {
   function swaggerApiMetadata (req, res, next) {
     // Only set req.swagger.api if the request is under the API's basePath
     if (context.api) {
-      let basePath = util.normalizePath(context.api.basePath, router);
       let reqPath = util.normalizePath(req.path, router);
-      if (_.startsWith(reqPath, basePath)) {
-        req.swagger.api = context.api;
+      // Swagger uses basePath
+      if (context.api.swagger) {
+        let basePath = util.normalizePath(context.api.basePath, router);
+        if (_.startsWith(reqPath, basePath)) {
+          req.swagger.api = context.api;
+          req.swagger.basePath = basePath;
+        }
+      }
+      // OpenAPI uses servers
+      else {
+        let servers = context.api.servers || [{ url: "/" }];
+        for (let server of servers) {
+          let pathname = url.parse(util.normalizePath(server.url, router)).pathname;
+          if (_.startsWith(reqPath, pathname)) {
+            req.swagger.api = context.api;
+            req.swagger.basePath = pathname;
+            break;
+          }
+        }
       }
     }
 
@@ -183,11 +200,11 @@ function swaggerSecurityMetadata (req, res, next) {
  * @returns {string}
  */
 function getRelativePath (req) {
-  if (!req.swagger.api.basePath) {
+  if (!req.swagger.basePath) {
     return req.path;
   }
   else {
-    return req.path.substr(req.swagger.api.basePath.length);
+    return req.path.substr(req.swagger.basePath.length);
   }
 }
 

--- a/lib/request-metadata.js
+++ b/lib/request-metadata.js
@@ -86,7 +86,7 @@ function requestMetadata (context, router) {
         util.debug("%s %s matches Swagger path %s", req.method, req.path, req.swagger.pathName);
       }
       else {
-        util.warn('WARNING! Unable to find a Swagger path that matches "%s"', req.path);
+        util.debug('Unable to find a Swagger path that matches "%s"', req.path);
       }
     }
 
@@ -162,7 +162,7 @@ function swaggerOperationMetadata (req, res, next) {
       req.swagger.operation = req.swagger.path[method];
     }
     else {
-      util.warn("WARNING! Unable to find a Swagger operation that matches %s %s", req.method.toUpperCase(), req.path);
+      util.debug("Unable to find a Swagger operation that matches %s %s", req.method.toUpperCase(), req.path);
     }
   }
 

--- a/test/specs/mock/mock.spec.js
+++ b/test/specs/mock/mock.spec.js
@@ -60,6 +60,7 @@ for (let spec of specs) {
               },
               paths: {}
             },
+            basePath: "",
             pathName: "",
             path: null,
             operation: null,
@@ -89,6 +90,7 @@ for (let spec of specs) {
         express.get("/api/pets", helper.spy((req, res, next) => {
           expect(req.swagger).to.deep.equal({
             api: spec.samples.petStore,
+            basePath: "/api",
             pathName: "/pets",
             path: spec.samples.petsPath,
             operation: spec.samples.petsGetOperation,

--- a/test/specs/request-metadata.spec.js
+++ b/test/specs/request-metadata.spec.js
@@ -20,6 +20,7 @@ for (let spec of specs) {
         express.post("/api/pets", helper.spy((req, res, next) => {
           expect(req.swagger).to.deep.equal({
             api: spec.samples.petStore,
+            basePath: "/api",
             pathName: "/pets",
             path: spec.samples.petsPath,
             operation: spec.samples.petsPostOperation,
@@ -42,6 +43,7 @@ for (let spec of specs) {
         let handler = helper.spy((req, res, next) => {
           expect(req.swagger).to.deep.equal({
             api: spec.samples.petStore,
+            basePath: "/api",
             pathName: "/pets/{PetName}",
             path: spec.samples.petPath,
             operation: spec.samples.petPatchOperation,
@@ -70,6 +72,7 @@ for (let spec of specs) {
         express.patch("/pets/fido", helper.spy((req, res, next) => {
           expect(req.swagger).to.deep.equal({
             api: spec.samples.petStoreNoBasePath,
+            basePath: "",
             pathName: "/pets/{PetName}",
             path: spec.samples.petPath,
             operation: spec.samples.petPatchOperation,
@@ -141,6 +144,7 @@ for (let spec of specs) {
             security: spec.samples.petStoreSecurity,
 
             // all other properties should be null
+            basePath: "/api",
             pathName: "",
             path: null,
             operation: null,
@@ -167,6 +171,7 @@ for (let spec of specs) {
             security: spec.samples.petStoreSecurity,
 
             // all other properties should be null
+            basePath: "/api",
             pathName: "",
             path: null,
             operation: null,
@@ -189,6 +194,7 @@ for (let spec of specs) {
           expect(req.swagger).to.deep.equal({
             // req.swagger.api and req.swagger.path should be set, even though the operation is not valid
             api: spec.samples.petStoreNoOperations,
+            basePath: "/api",
             pathName: "/pets/{PetName}",
             path: spec.samples.petPathNoOperations,
 
@@ -218,6 +224,7 @@ for (let spec of specs) {
           expect(req.swagger).to.deep.equal({
             // req.swagger.api and req.swagger.path should be set, even though the operation is not valid
             api: spec.samples.petStore,
+            basePath: "/api",
             pathName: "/pets/{PetName}",
             path: spec.samples.petPath,
 
@@ -248,6 +255,7 @@ for (let spec of specs) {
         let handler = helper.spy((req, res, next) => {
           expect(req.swagger).to.deep.equal({
             api: spec.samples.petStore,
+            basePath: "/api",
             pathName: "/pets/{PetName}",
             path: spec.samples.petPath,
             operation: spec.samples.petPatchOperation,
@@ -292,6 +300,7 @@ for (let spec of specs) {
             security: spec.samples.petStoreSecurity,
 
             // all other properties should be null
+            basePath: "/api",
             pathName: "",
             path: null,
             operation: null,
@@ -326,6 +335,7 @@ for (let spec of specs) {
             security: spec.samples.petStoreSecurity,
 
             // all other properties should be null
+            basePath: "/api",
             pathName: "",
             path: null,
             operation: null,
@@ -356,6 +366,7 @@ for (let spec of specs) {
             security: spec.samples.petStoreSecurity,
 
             // all other properties should be null
+            basePath: "/api",
             pathName: "",
             path: null,
             operation: null,
@@ -387,6 +398,7 @@ for (let spec of specs) {
         let handler = helper.spy((req, res, next) => {
           expect(req.swagger).to.deep.equal({
             api: spec.samples.petStore,
+            basePath: "/api",
             pathName: "/pets/{PetName}",
             path: spec.samples.petPath,
             operation: spec.samples.petPatchOperation,
@@ -430,6 +442,7 @@ for (let spec of specs) {
             security: spec.samples.petStoreSecurity,
 
             // all other properties should be null
+            basePath: "/api",
             pathName: "",
             path: null,
             operation: null,
@@ -464,6 +477,7 @@ for (let spec of specs) {
             security: spec.samples.petStoreSecurity,
 
             // all other properties should be null
+            basePath: "/api",
             pathName: "",
             path: null,
             operation: null,
@@ -494,6 +508,7 @@ for (let spec of specs) {
             security: spec.samples.petStoreSecurity,
 
             // all other properties should be null
+            basePath: "/api",
             pathName: "",
             path: null,
             operation: null,
@@ -545,6 +560,7 @@ for (let spec of specs) {
                 },
                 paths: {}
               },
+              basePath: "",
               pathName: "",
               path: null,
               operation: null,
@@ -556,6 +572,7 @@ for (let spec of specs) {
             // req.swagger DOES get populated on the second request, because the API is now valid
             expect(req.swagger).to.deep.equal({
               api: spec.samples.petStore,
+              basePath: "/api",
               pathName: "/pets/{PetName}",
               path: spec.samples.petPath,
               operation: spec.samples.petPatchOperation,


### PR DESCRIPTION
With OpenAPI 3, basePath is not used anymore.
Instead, an array of servers is provided and should be used.
The found base path (either basePath in swagger or one of the servers in OpenAPI) is kept on the request to be used later.
NOTES:
1. Unit tests have been updated. All pass.
2. Templating is not yet supported on the servers.
