### PR TITLE
Support ISO 8601 times which are missing a colon

### DIFF
--- a/lib/helpers/json-schema.js
+++ b/lib/helpers/json-schema.js
@@ -15,7 +15,7 @@ let dataTypePatterns = {
 
   date: /^\d{4}-\d{2}-\d{2}$/,
 
-  "date-time": /^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}(\.\d+)?(Z|[+-]\d{2}:\d{2})$/i
+  "date-time": /^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}(\.\d+)?(Z|[+-]\d{2}:?\d{2})$/i
 };
 
 // Some older versions of Node don't define these constants


### PR DESCRIPTION
+00:00 and +0000 are both valid according to https://en.wikipedia.org/wiki/ISO_8601