### PR TITLE
RequestValidator (security) - Openapi 3 support

### DIFF
--- a/lib/request-validator.js
+++ b/lib/request-validator.js
@@ -159,7 +159,7 @@ function http413 (req, res, next) {
   if (util.isSwaggerRequest(req)) {
     // Determine if the request allows body content
     let bodyAllowed = req.swagger.params.some((param) => {
-      return param.in === "body" || param.in === "formData";
+      return param.in === "body" || param.in === "formData" || param.in === "requestBody";
     });
 
     if (!bodyAllowed) {

--- a/lib/request-validator.js
+++ b/lib/request-validator.js
@@ -44,7 +44,12 @@ function http401 (req, res, next) {
     // Loop through each Security Requirement (if ANY of them are met, then the request is valid)
     let isValid = req.swagger.security.some((requirement) => {
       let securityDefinitions = _.map(requirement, (scopes, name) => {
-        return req.swagger.api.securityDefinitions[name];
+        const securitySchemes =
+          // OpenAPI 2.0
+          req.swagger.api.securityDefinitions ||
+          // OpenAPI 3.0
+          _.get(req, "swagger.api.components.securitySchemes", {});
+        return securitySchemes[name];
       });
 
       // Loop through each Security Definition (if ALL of them are met, then the request is valid)
@@ -53,7 +58,9 @@ function http401 (req, res, next) {
           securityTypes.push(securityDef.type);
         }
 
-        if (securityDef.type === "basic") {
+        if (securityDef.type === "basic" ||
+           // OpenAPI 3.0
+           (securityDef.type === "http" && securityDef.scheme === "basic")) {
           return _.startsWith(req.header("Authorization"), "Basic ");
         }
         else if (securityDef.type === "apiKey" && securityDef.in === "header") {
@@ -61,6 +68,11 @@ function http401 (req, res, next) {
         }
         else if (securityDef.type === "apiKey" && securityDef.in === "query") {
           return req.query[securityDef.name] !== undefined;
+        }
+        // OpenAPI 3.0 allows in cookie
+        else if (securityDef.type === "apiKey" && securityDef.in === "cookie") {
+          return req.cookies[securityDef.name] !== undefined ||
+          req.signedCookies[securityDef.name] !== undefined;
         }
         else {
           // For any other type of security, just assume it's valid.
@@ -158,11 +170,11 @@ function http406 (req, res, next) {
 function http413 (req, res, next) {
   if (util.isSwaggerRequest(req)) {
     // Determine if the request allows body content
-    let bodyAllowed = 
+    let bodyAllowed =
     // OpenAPI 2.0
     req.swagger.params.some((param) => {
       return param.in === "body" || param.in === "formData";
-    }) || 
+    }) ||
     // OpenAPI 3.0
     req.swagger.operation.requestBody;
 

--- a/lib/request-validator.js
+++ b/lib/request-validator.js
@@ -159,8 +159,8 @@ function http413 (req, res, next) {
   if (util.isSwaggerRequest(req)) {
     // Determine if the request allows body content
     let bodyAllowed = req.swagger.params.some((param) => {
-      return param.in === "body" || param.in === "formData" || param.in === "requestBody";
-    });
+      return param.in === "body" || param.in === "formData";
+    }) || req.swagger.requestBody;
 
     if (!bodyAllowed) {
       // NOTE: We used to also check the Transfer-Encoding header, but that fails in Node 0.10.x

--- a/lib/request-validator.js
+++ b/lib/request-validator.js
@@ -160,7 +160,7 @@ function http413 (req, res, next) {
     // Determine if the request allows body content
     let bodyAllowed = req.swagger.params.some((param) => {
       return param.in === "body" || param.in === "formData";
-    }) || req.swagger.requestBody;
+    }) || req.swagger.operation.requestBody;
 
     if (!bodyAllowed) {
       // NOTE: We used to also check the Transfer-Encoding header, but that fails in Node 0.10.x

--- a/lib/request-validator.js
+++ b/lib/request-validator.js
@@ -158,9 +158,13 @@ function http406 (req, res, next) {
 function http413 (req, res, next) {
   if (util.isSwaggerRequest(req)) {
     // Determine if the request allows body content
-    let bodyAllowed = req.swagger.params.some((param) => {
+    let bodyAllowed = 
+    // OpenAPI 2.0
+    req.swagger.params.some((param) => {
       return param.in === "body" || param.in === "formData";
-    }) || req.swagger.operation.requestBody;
+    }) || 
+    // OpenAPI 3.0
+    req.swagger.operation.requestBody;
 
     if (!bodyAllowed) {
       // NOTE: We used to also check the Transfer-Encoding header, but that fails in Node 0.10.x

--- a/test/specs/request-metadata.spec.js
+++ b/test/specs/request-metadata.spec.js
@@ -7,7 +7,7 @@ const specs = require("../utils/specs");
 const helper = require("../utils/helper");
 
 for (let spec of specs) {
-  describe.only(`RequestMetadata middleware (${spec.name})`, () => {
+  describe(`RequestMetadata middleware (${spec.name})`, () => {
 
     it("should set all req.swagger properties for a parameterless path", (done) => {
       swagger(spec.files.petStore, (err, middleware) => {

--- a/test/specs/request-validator.spec.js
+++ b/test/specs/request-validator.spec.js
@@ -9,7 +9,7 @@ const specs = require("../utils/specs");
 const helper = require("../utils/helper");
 
 for (let spec of specs) {
-  describe(`RequestValidator middleware (${spec.name})`, () => {
+  describe.only(`RequestValidator middleware (${spec.name})`, () => {
     let api, express, supertest;
 
     beforeEach(() => {
@@ -229,7 +229,7 @@ for (let spec of specs) {
         });
       });
 
-      it.only("should NOT throw an HTTP 401 if an ApiKey authentication requirement is met (in cookie)", (done) => {
+      it("should NOT throw an HTTP 401 if an ApiKey authentication requirement is met (in cookie)", (done) => {
         if (spec.name === "OpenAPI 3.0") {
           api.components.securitySchemes.petStoreApiKey.in = "cookie";
         }


### PR DESCRIPTION
Needed to fix the securityDefinitions for 3.0. It is renamed to securitySchemes and moved it under components. The basic is now in scheme under type, and added cookie support.