### PR TITLE
Keep the slash when base path is set to slash

### DIFF
--- a/lib/request-metadata.js
+++ b/lib/request-metadata.js
@@ -183,7 +183,7 @@ function swaggerSecurityMetadata (req, res, next) {
  * @returns {string}
  */
 function getRelativePath (req) {
-  if (!req.swagger.api.basePath) {
+  if (!req.swagger.api.basePath || req.swagger.api.basePath === "/") {
     return req.path;
   }
   else {


### PR DESCRIPTION
If basePath is / then it removes the original / from the paths defined in the swagger file.