### PR TITLE
improve metadata fitting performance

### DIFF
--- a/lib/middleware.js
+++ b/lib/middleware.js
@@ -60,6 +60,7 @@ function Middleware (sharedRouter) {
 
       context.error = err;
       context.api = api;
+      context.pathRegexCache = {};
       context.parser = parser;
       context.emit("change");
 

--- a/lib/request-metadata.js
+++ b/lib/request-metadata.js
@@ -58,7 +58,7 @@ function requestMetadata (context, router) {
           req.swagger.pathName = swaggerPath;
           return true;
         }
-        else if (req.swagger.path === null && pathMatches(relPathNormalized, swaggerPathNormalized)) {
+        else if (req.swagger.path === null && pathMatches(relPathNormalized, swaggerPathNormalized, context)) {
           // We found a possible match, but keep searching in case we find an exact match
           req.swagger.path = req.swagger.api.paths[swaggerPath];
           req.swagger.pathName = swaggerPath;
@@ -196,9 +196,14 @@ function getRelativePath (req) {
  *
  * @param   {string}    path        - The request path (e.g. "/users/jdoe/orders/1234")
  * @param   {string}    swaggerPath - The Swagger path (e.g. "/users/{username}/orders/{orderId}")
+ * @param   {object}    context     - The Middleware context
  * @returns {boolean}
  */
-function pathMatches (path, swaggerPath) {
+function pathMatches (path, swaggerPath, context) {
+  if (context.pathRegexCache[swaggerPath]) {
+    return context.pathRegexCache[swaggerPath].test(path);
+  }
+
   // Convert the Swagger path to a RegExp
   let pathPattern = swaggerPath.replace(util.swaggerParamRegExp, (match, paramName) => {
     return "([^/]+)";
@@ -206,6 +211,9 @@ function pathMatches (path, swaggerPath) {
 
   // NOTE: This checks for an EXACT, case-sensitive match
   let pathRegExp = new RegExp("^" + pathPattern + "$");
+
+  // Cache swagger path regex for performance
+  context.pathRegexCache[swaggerPath] = pathRegExp;
 
   return pathRegExp.test(path);
 }


### PR DESCRIPTION
This is to fix the issue #154 
Initially I have tried to attach the regex cache to swagger.api.paths object per swagger path but it caused many test failures as it modified the swagger.api object. I have fixed all unit tests related to metadata but that wasn't enough as there are other tests validating swagger object. 
Hence now I am attaching the regex cache to context root level to avoid modifying swagger.api object and all unit tests are passing.

@JamesMessinger , please let me know what you think of the change. I can add unit tests if this change is acceptable.
