### PR TITLE
Don't allow non-numeric characters when parsing the `number` type.

### DIFF
--- a/lib/helpers/json-schema.js
+++ b/lib/helpers/json-schema.js
@@ -278,7 +278,7 @@ function parseNumber (schema, value, propPath) {
   value = getValueToValidate(schema, value);
 
   // Make sure it's a properly-formatted number
-  let parsedValue = parseFloat(value);
+  let parsedValue = value === "" ? NaN : Number(value);
   if (_.isNaN(parsedValue) || !_.isFinite(parsedValue)) {
     throw ono({ status: 400 }, '"%s" is not a valid numeric value', propPath || value);
   }

--- a/test/specs/json-schema/parse/parse-number.spec.js
+++ b/test/specs/json-schema/parse/parse-number.spec.js
@@ -177,4 +177,19 @@ describe("JSON Schema - parse number params", () => {
       expect(err.message).to.contain('Missing required header parameter "Test"');
     }));
   });
+
+  it("should be more strict than parseFloat()", (done) => {
+    let schema = {
+      type: "number",
+      required: true
+    };
+
+    let express = helper.parse(schema, "1z", done);
+
+    express.use("/api/test", helper.spy((err, req, res, next) => {
+      expect(err).to.be.an.instanceOf(Error);
+      expect(err.status).to.equal(400);
+      expect(err.message).to.contain('"1z" is not a valid numeric value');
+    }));
+  });
 });


### PR DESCRIPTION
If there are non-numeric characters following leading digits in its input, `parseFloat()` will strip them and simply allow the leading digits through, e.g. `1abc` becomes `1`. This change makes the number check more strict, requiring that all characters be numeric.