### PR TITLE
Fix inconsistent import issue of ono module

### DIFF
--- a/lib/data-store/index.js
+++ b/lib/data-store/index.js
@@ -3,7 +3,7 @@
 module.exports = DataStore;
 
 const _ = require("lodash");
-const ono = require("@jsdevtools/ono");
+const { ono } = require("@jsdevtools/ono");
 const util = require("../helpers/util");
 const Resource = require("./resource");
 require("./buffer-polyfill");

--- a/lib/data-store/resource.js
+++ b/lib/data-store/resource.js
@@ -3,7 +3,7 @@
 module.exports = Resource;
 
 const util = require("../helpers/util");
-const ono = require("@jsdevtools/ono");
+const { ono } = require("@jsdevtools/ono");
 const _ = require("lodash");
 
 /**

--- a/lib/helpers/json-schema.js
+++ b/lib/helpers/json-schema.js
@@ -3,7 +3,7 @@
 module.exports = JsonSchema;
 
 const tv4 = require("tv4");
-const ono = require("@jsdevtools/ono");
+const { ono } = require("@jsdevtools/ono");
 const _ = require("lodash");
 
 // Supported data types

--- a/lib/mock/index.js
+++ b/lib/mock/index.js
@@ -3,7 +3,7 @@
 module.exports = mock;
 
 const _ = require("lodash");
-const ono = require("@jsdevtools/ono");
+const { ono } = require("@jsdevtools/ono");
 const path = require("path");
 const fs = require("fs");
 const typeIs = require("type-is");

--- a/lib/mock/query-resource.js
+++ b/lib/mock/query-resource.js
@@ -7,7 +7,7 @@ module.exports = {
 };
 
 const util = require("../helpers/util");
-const ono = require("@jsdevtools/ono");
+const { ono } = require("@jsdevtools/ono");
 const Resource = require("../data-store/resource");
 
 /**

--- a/lib/param-parser.js
+++ b/lib/param-parser.js
@@ -4,7 +4,7 @@ module.exports = paramParser;
 module.exports.parseParameter = parseParameter;
 
 const _ = require("lodash");
-const ono = require("@jsdevtools/ono");
+const { ono } = require("@jsdevtools/ono");
 const util = require("./helpers/util");
 const JsonSchema = require("./helpers/json-schema");
 

--- a/lib/request-validator.js
+++ b/lib/request-validator.js
@@ -3,7 +3,7 @@
 module.exports = requestValidator;
 
 const util = require("./helpers/util");
-const ono = require("@jsdevtools/ono");
+const { ono } = require("@jsdevtools/ono");
 const _ = require("lodash");
 
 /**


### PR DESCRIPTION
context:
when using this module in the context of webpack, you would get something like 
 ```

2020-10-27T05:09:55.963Z	7f428527-14e4-425d-aa64-ab15a551611a	ERROR	TypeError: ono is not a function
    at parseParameter (/var/task/vendors~lambda.js:6942:11)
    at /var/task/vendors~lambda.js:6884:18
    at Array.some (<anonymous>)
    at parseBodyParam (/var/task/vendors~lambda.js:6868:10)
    at Layer.handle [as handle_request] (/var/task/vendors~lambda.js:69862:5)
    at trim_prefix (/var/task/vendors~lambda.js:69414:13)
    at /var/task/vendors~lambda.js:69381:7
    at Function.process_params (/var/task/vendors~lambda.js:69432:12)
    at next (/var/task/vendors~lambda.js:69372:10)
    at parseFormDataParams (/var/task/vendors~lambda.js:6859:3)
2020-10-27T05:09:55.963Z 7f428527-14e4-425d-aa64-ab15a551611a ERROR TypeError: ono is not a function at parseParameter (/var/task/vendors~lambda.js:6942:11) at /var/task/vendors~lambda.js:6884:18 at Array.some (<anonymous>) at parseBodyParam (/var/task/vendors~lambda.js:6868:10) at Layer.handle [as handle_request] (/var/task/vendors~lambda.js:69862:5) at trim_prefix (/var/task/vendors~lambda.js:69414:13) at /var/task/vendors~lambda.js:69381:7 at Function.process_params (/var/task/vendors~lambda.js:69432:12) at next (/var/task/vendors~lambda.js:69372:10) at parseFormDataParams (/var/task/vendors~lambda.js:6859:3)
```
this is because the `ono` module import is not working, to fix this, it will need to be consistent with the ways of import from @jsdevtools which is 

```const { ono } = require("@jsdevtools/ono");```

could you please accept this PR as I am waiting for this to deploy new feature in our project, thanks.